### PR TITLE
Conversion for .NET Standard 2.0

### DIFF
--- a/PicartoWrapperAPI/PicartoWrapperAPI.csproj
+++ b/PicartoWrapperAPI/PicartoWrapperAPI.csproj
@@ -1,98 +1,23 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{2933E963-761C-4314-9C08-95FD16FC2A2A}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>PicartoWrapperAPI</RootNamespace>
-    <AssemblyName>PicartoWrapperAPI</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyTitle>PicartoWrapperAPI</AssemblyTitle>
+    <Product>PicartoWrapperAPI</Product>
+    <Copyright>Copyright ©  2017</Copyright>
+    <OutputPath>bin\$(Configuration)\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <DebugType>portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="RestSharp, Version=106.1.0.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
-      <HintPath>..\packages\RestSharp.106.1.0\lib\net452\RestSharp.dll</HintPath>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Web" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="RestSharp" Version="106.6.10" />
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Clients\PicartoAuthenticatedClient.cs" />
-    <Compile Include="Clients\PicartoReadOnlyClient.cs" />
-    <Compile Include="Enums\Account_type.cs" />
-    <Compile Include="Enums\ChannelState.cs" />
-    <Compile Include="Enums\IPageList.cs" />
-    <Compile Include="Enums\SortDirection.cs" />
-    <Compile Include="Enums\State.cs" />
-    <Compile Include="Models\Data\User\Bot.cs" />
-    <Compile Include="Models\Data\User\Streamkey.cs" />
-    <Compile Include="Models\Result\Categories.cs" />
-    <Compile Include="Models\Result\ChannelSearchResults.cs" />
-    <Compile Include="Models\Result\Events.cs" />
-    <Compile Include="Models\Data\User\Thumbnail.cs" />
-    <Compile Include="Helpers\PagedList.cs" />
-    <Compile Include="Helpers\PagingInfo.cs" />
-    <Compile Include="Helpers\PicartoConnection.cs" />
-    <Compile Include="Helpers\PicartoExeption.cs" />
-    <Compile Include="Helpers\PicartoHelper.cs" />
-    <Compile Include="Helpers\PicartoJsonDeserializer.cs" />
-    <Compile Include="Helpers\PicartoListConverter.cs" />
-    <Compile Include="Helpers\RequestExtensions.cs" />
-    <Compile Include="Interfaces\IJsonSerializer.cs" />
-    <Compile Include="Interfaces\IPicartoClient.cs" />
-    <Compile Include="Models\Data\Channel\BasicChannelInfo.cs" />
-    <Compile Include="Models\Data\Public\Category.cs" />
-    <Compile Include="Models\Data\Channel\Channel.cs" />
-    <Compile Include="Models\Data\Channel\ChannelVideo.cs" />
-    <Compile Include="Models\Data\User\DescriptionPanel.cs" />
-    <Compile Include="Models\Data\Public\Event.cs" />
-    <Compile Include="Models\Data\User\Following.cs" />
-    <Compile Include="Models\Data\User\Language.cs" />
-    <Compile Include="Models\Data\User\Multistream.cs" />
-    <Compile Include="Models\Result\Languages.cs" />
-    <Compile Include="Models\Result\OnlineChannels.cs" />
-    <Compile Include="Models\Data\Public\OnlineDetails.cs" />
-    <Compile Include="Models\PicartoList.cs" />
-    <Compile Include="Models\PicartoResponse.cs" />
-    <Compile Include="Models\Data\User\Subscription.cs" />
-    <Compile Include="Models\Data\User\UserData.cs" />
-    <Compile Include="Models\Result\VideoSearchResult.cs" />
-    <Compile Include="Models\Result\VideoSearchResults.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup />
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/PicartoWrapperAPI/Properties/AssemblyInfo.cs
+++ b/PicartoWrapperAPI/Properties/AssemblyInfo.cs
@@ -2,18 +2,6 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("PicartoWrapperAPI")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("PicartoWrapperAPI")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
@@ -21,16 +9,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("2933e963-761c-4314-9c08-95fd16fc2a2a")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/PicartoWrapperAPI/packages.config
+++ b/PicartoWrapperAPI/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
-  <package id="RestSharp" version="106.1.0" targetFramework="net461" />
-</packages>


### PR DESCRIPTION
Needed to use this library for a .NET Core library but couldn't get it to work. As .NET Standard is compatible with .NET Framework AND .NET Core projects alike, I ported it to that target.

From what I can tell, things still work as normal, but now this library can be used cross-platform.